### PR TITLE
EngineNavFragment优化

### DIFF
--- a/engine/src/main/java/com/drake/engine/base/EngineNavFragment.kt
+++ b/engine/src/main/java/com/drake/engine/base/EngineNavFragment.kt
@@ -46,7 +46,8 @@ abstract class EngineNavFragment<B : ViewDataBinding>(@LayoutRes contentLayoutId
     protected abstract fun initData()
     override fun onClick(v: View) {}
 
-    override fun onResume() {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        binding = DataBindingUtil.bind(view)!!
         try {
             initView()
             initData()
@@ -54,11 +55,6 @@ abstract class EngineNavFragment<B : ViewDataBinding>(@LayoutRes contentLayoutId
             Log.e("Engine", "Initializing failure")
             e.printStackTrace()
         }
-        super.onResume()
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        binding = DataBindingUtil.bind(view)!!
     }
 
 }


### PR DESCRIPTION
说明：因为navigation的退回机制会执行onCreateView -》onViewCreated 所以init写在onViewCreated也是可以的 而且写在onResume中每次回到手机桌面在到APP  会执行init